### PR TITLE
Clean version value display

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="password">Password</string>
 
     <string name="app_info">About</string>
-    <string name="about_version">v%1$s</string>
+    <string name="about_version">%1$s</string>
     <string name="about_engine">GeckoView %1$s</string>
     <string name="about_description">A lightweight browser for web apps\nPowered by Mozilla GeckoView</string>
     <string name="about_github">GitHub</string>


### PR DESCRIPTION
The about dialog currently displays a double `v` letter, ie `vv0.30.3`.  I am not sure where the version string is generated but the simplest solution seems to be to not add a prefix in the about dialog.